### PR TITLE
Fix cgihandler to accept spaces in CGIInterpreter.

### DIFF
--- a/lib/webrick/httpservlet/cgihandler.rb
+++ b/lib/webrick/httpservlet/cgihandler.rb
@@ -36,7 +36,7 @@ module WEBrick
         super(server, name)
         @script_filename = name
         @tempdir = server[:TempDir]
-        @cgicmd = "#{CGIRunner} #{server[:CGIInterpreter]}"
+        @cgicmd = "#{CGIRunner} \"#{server[:CGIInterpreter]}\""
       end
 
       # :stopdoc:


### PR DESCRIPTION
Hi,

I noticed a bug in `cgihandler.rb` when `:CGIInterpreter` contains spaces which breaks `ARGV` in multiple elements in `cgi_runner.rb`. This commit corrects that by quoting the relevant variable in `cgihandler.rb`.