### PR TITLE
Silence Net::HTTP warning in test

### DIFF
--- a/test/webrick/test_httpproxy.rb
+++ b/test/webrick/test_httpproxy.rb
@@ -64,6 +64,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
 
       req = Net::HTTP::Post.new("/")
       req.body = "post-data"
+      req.content_type = "application/x-www-form-urlencoded"
       http.request(req){|res|
         assert_equal("1.1 localhost.localdomain:#{port}", res["via"], log.call)
         assert_equal("POST / post-data", res.body, log.call)
@@ -108,6 +109,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
       assert_equal(2, request_handler_called, log.call)
 
       req = Net::HTTP::Post.new("/")
+      req.content_type = "application/x-www-form-urlencoded"
       req.body = "post-data"
       http.request(req){|res|
         assert_nil(res["via"], log.call)
@@ -241,6 +243,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
 
         req = Net::HTTP::Post.new("/")
         req.body = "post-data"
+        req.content_type = "application/x-www-form-urlencoded"
         http.request(req){|res|
           via = res["via"].split(/,\s+/)
           assert(via.include?("1.1 localhost.localdomain:#{up_port}"), up_log.call + log.call)
@@ -285,6 +288,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
 
             req2 = Net::HTTP::Post.new("/")
             req2.body = "post-data"
+            req2.content_type = "application/x-www-form-urlencoded"
             http.request(req2){|res|
               assert_equal("SSL POST / post-data", res.body, up_log.call + log.call + s_log.call)
             }


### PR DESCRIPTION
Net::HTTP warns about setting the default content_type when using POST verb:

> Content-Type did not set; using application/x-www-form-urlencoded

Before

![webrick_test_before](https://user-images.githubusercontent.com/1037088/35435568-116dc1d4-0240-11e8-9160-09408a01c929.png)

After

![webrick_test_after](https://user-images.githubusercontent.com/1037088/35435573-198135ea-0240-11e8-8b34-42f4834fdea9.png)
