### PR TITLE
Add missing test for WEBrick::HTTPAuth::Htgroup

### DIFF
--- a/test/webrick/test_htgroup.rb
+++ b/test/webrick/test_htgroup.rb
@@ -1,0 +1,19 @@
+require "tempfile"
+require "test/unit"
+require "webrick/httpauth/htgroup"
+
+class TestHtgroup < Test::Unit::TestCase
+  def test_htgroup
+    Tempfile.create('test_htgroup') do |tmpfile|
+      tmpfile.close
+      tmp_group = WEBrick::HTTPAuth::Htgroup.new(tmpfile.path)
+      tmp_group.add 'superheroes', %w[spiderman batman]
+      tmp_group.add 'supervillains', %w[joker]
+      tmp_group.flush
+
+      htgroup = WEBrick::HTTPAuth::Htgroup.new(tmpfile.path)
+      assert_equal(htgroup.members('superheroes'), %w[spiderman batman])
+      assert_equal(htgroup.members('supervillains'), %w[joker])
+    end
+  end
+end


### PR DESCRIPTION
Add test for class `WEBRick::HTTPAuth::Htgroup`. A test for this class is missing.