### PR TITLE
Remove extraneous spaces at the end of status line

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -119,7 +119,7 @@ module WEBrick
     # The response's HTTP status line
 
     def status_line
-      "HTTP/#@http_version #@status #@reason_phrase #{CRLF}"
+      "HTTP/#@http_version #@status #@reason_phrase".rstrip << CRLF
     end
 
     ##

--- a/test/webrick/test_httpresponse.rb
+++ b/test/webrick/test_httpresponse.rb
@@ -222,5 +222,12 @@ module WEBrick
       assert_match(/#{@res.reason_phrase}/, body)
       assert_match(/#{message}/, body)
     end
+
+    def test_no_extraneous_space
+      [200, 300, 400, 500].each do |status|
+        @res.status = status
+        assert_match(/\S\r\n/, @res.status_line)
+      end
+    end
   end
 end


### PR DESCRIPTION
Remove extraneous spaces after the status code that is
non-compliant with RFC, i.e `HTTP 200 OK `, to unnecessary
confusion for WEBrick users, by a risk that WEBrick instances in
the wild will have server responses flagged as suspicious or
malicious due to a similar bug in [Cobalt Strike
misconfiguration].

Reported by Matt Tennis <mtennis@paloaltonetworks.com>

[Cobalt Strike misconfiguration]: https://blog.fox-it.com/2019/02/26/identifying-cobalt-strike-team-servers-in-the-wild/