### PR TITLE
Improve httpstatus.rb's test coverage

### DIFF
--- a/test/webrick/test_httpstatus.rb
+++ b/test/webrick/test_httpstatus.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: false
+require "test/unit"
+require "webrick"
+
+class TestWEBrickHTTPStatus < Test::Unit::TestCase
+  def test_info?
+    assert WEBrick::HTTPStatus.info?(100)
+    refute WEBrick::HTTPStatus.info?(200)
+  end
+
+  def test_success?
+    assert WEBrick::HTTPStatus.success?(200)
+    refute WEBrick::HTTPStatus.success?(300)
+  end
+
+  def test_redirect?
+    assert WEBrick::HTTPStatus.redirect?(300)
+    refute WEBrick::HTTPStatus.redirect?(400)
+  end
+
+  def test_error?
+    assert WEBrick::HTTPStatus.error?(400)
+    refute WEBrick::HTTPStatus.error?(600)
+  end
+
+  def test_client_error?
+    assert WEBrick::HTTPStatus.client_error?(400)
+    refute WEBrick::HTTPStatus.client_error?(500)
+  end
+
+  def test_server_error?
+    assert WEBrick::HTTPStatus.server_error?(500)
+    refute WEBrick::HTTPStatus.server_error?(600)
+  end
+end


### PR DESCRIPTION
Hi,

This PR improves the test coverage of httpstatus.rb from __92.5%__ to __100.0%__.

The coverage at the moment.
https://rubyci.s3.amazonaws.com/debian8-coverage/ruby-trunk/lcov/ruby/lib/webrick/httpstatus.rb.gcov.html

With this PR
<img width="523" alt="スクリーンショット 2019-06-19 11 27 57" src="https://user-images.githubusercontent.com/26586593/59790677-5839cf00-9285-11e9-90f2-732547d3f1da.png">
