### PR TITLE
fix HTTPResponse#to_s using stringio

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -11,6 +11,7 @@
 
 require 'time'
 require 'uri'
+require 'stringio'
 require_relative 'httpversion'
 require_relative 'htmlutils'
 require_relative 'httputils'
@@ -319,9 +320,9 @@ module WEBrick
     end
 
     def to_s # :nodoc:
-      ret = ""
+      ret = StringIO.new
       send_response(ret)
-      ret
+      ret.string
     end
 
     ##

--- a/test/webrick/test_httpresponse.rb
+++ b/test/webrick/test_httpresponse.rb
@@ -3,6 +3,7 @@ require "webrick"
 require "minitest/autorun"
 require "stringio"
 require "net/http"
+require "time"
 
 module WEBrick
   class TestHTTPResponse < MiniTest::Unit::TestCase
@@ -228,6 +229,24 @@ module WEBrick
         @res.status = status
         assert_match(/\S\r\n/, @res.status_line)
       end
+    end
+
+    def test_to_s
+      date = Time.now.httpdate
+      # HTTPResponse with #body = 'hoge' and #keep_alive = true
+      expected = <<~_end_of_message_.chomp.gsub(LF, CRLF)
+        HTTP/1.1 200 OK
+        Date: #{date}
+        Server: #{config[:ServerSoftware]}
+        Content-Length: 4
+        Connection: Keep-Alive
+
+        hoge
+      _end_of_message_
+
+      res.body = 'hoge'
+      res['Date'] = date
+      assert_equal expected, res.to_s
     end
   end
 end


### PR DESCRIPTION
Hi!

This PR fixes `WEBrick::HTTPResponse#to_s`.
The following code that is according to the `HTTPResponse#to_s` document raises an error.

```
irb(main):001:0> require 'webrick'
=> true
irb(main):002:0> res = WEBrick::HTTPResponse.new(HTTPVersion: '1.1')
=> #<WEBrick::HTTPResponse:0x00007feae59e0868 @config={:HTTPVersion=>"1.1"}, @buffer_size=nil, @logger=nil, @header={}, @status=200, @reason_phrase=nil, @http_version=#<WEBrick::HTTPVersion:0x00007feae59e0818 @minor=1, @major=1>, @body="", @keep_alive=true, @cookies=[], @request_method=nil, @request_uri=nil, @request_http_version=#<WEBrick::HTTPVersion:0x00007feae59e0818 @minor=1, @major=1>, @chunked=false, @filename=nil, @sent_size=0>
irb(main):003:0> res.body = 'hoge'
=> "hoge"
irb(main):004:0> res.to_s
Traceback (most recent call last):
        7: from /Users/thekuwayama/.rbenv/versions/2.6.3/bin/irb:23:in `<main>'
        6: from /Users/thekuwayama/.rbenv/versions/2.6.3/bin/irb:23:in `load'
        5: from /Users/thekuwayama/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        4: from (irb):4
        3: from /Users/thekuwayama/.rbenv/versions/2.6.3/lib/ruby/2.6.0/webrick/httpresponse.rb:323:in `to_s'
        2: from /Users/thekuwayama/.rbenv/versions/2.6.3/lib/ruby/2.6.0/webrick/httpresponse.rb:208:in `send_response'
        1: from /Users/thekuwayama/.rbenv/versions/2.6.3/lib/ruby/2.6.0/webrick/httpresponse.rb:217:in `rescue in send_response'
NoMethodError (undefined method `error' for nil:NilClass)
```