### PR TITLE
add EnvUtil#timeout

### DIFF
--- a/test/lib/envutil.rb
+++ b/test/lib/envutil.rb
@@ -55,6 +55,13 @@ module EnvUtil
   end
   module_function :apply_timeout_scale
 
+  def timeout(sec, klass = nil, message = nil, &blk)
+    return yield(sec) if sec == nil or sec.zero?
+    sec = apply_timeout_scale(sec)
+    Timeout.timeout(sec, klass, message, &blk)
+  end
+  module_function :timeout
+
   def invoke_ruby(args, stdin_data = "", capture_stdout = false, capture_stderr = false,
                   encoding: nil, timeout: 10, reprieve: 1, timeout_error: Timeout::Error,
                   stdout_filter: nil, stderr_filter: nil,

--- a/test/webrick/test_filehandler.rb
+++ b/test/webrick/test_filehandler.rb
@@ -308,7 +308,7 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
     TestWEBrick.start_httpserver(config, log_tester) do |server, addr, port, log|
       http = Net::HTTP.new(addr, port)
       http.read_timeout = EnvUtil.apply_timeout_scale(60)
-      http.write_timeout = EnvUtil.apply_timeout_scale(60)
+      http.write_timeout = EnvUtil.apply_timeout_scale(60) if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
 
       req = Net::HTTP::Get.new("/webrick.cgi/test")
       http.request(req) do |res|


### PR DESCRIPTION
Hi!

This PR adds `EnvUtil#timeout` to run a test of CI.
This module_function is missing.

- https://travis-ci.org/ruby/webrick/builds/549516037

I used [ruby/ruby](https://github.com/ruby/ruby/blob/master/tool/lib/envutil.rb#L68L73) to add `EnvUtil#timeout` as a reference.
Please comment if it should be solved in other ways.