### PR TITLE
Remove Webrick::HTTPResponse#to_s

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -318,12 +318,6 @@ module WEBrick
       end
     end
 
-    def to_s # :nodoc:
-      ret = ""
-      send_response(ret)
-      ret
-    end
-
     ##
     # Redirects to +url+ with a WEBrick::HTTPStatus::Redirect +status+.
     #


### PR DESCRIPTION
It is currently broken, and even if it worked, it can cause problems
when debugging.  See https://bugs.ruby-lang.org/issues/10715.

I think this is better than fixing the method, which is the approach
that #20 is taking.