### PR TITLE
Remove the squishing of whitespace in header values

### DIFF
--- a/lib/webrick/httputils.rb
+++ b/lib/webrick/httputils.rb
@@ -162,10 +162,7 @@ module WEBrick
         end
       }
       header.each{|key, values|
-        values.each{|value|
-          value.strip!
-          value.gsub!(/\s+/, " ")
-        }
+        values.each(&:strip!)
       }
       header
     end

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -135,7 +135,7 @@ GET /
     assert_equal("", req.script_name)
     assert_equal("/foo/baz", req.path_info)
     assert_equal("9", req['content-length'])
-    assert_equal("FOO BAR BAZ", req['user-agent'])
+    assert_equal("FOO   BAR BAZ", req['user-agent'])
     assert_equal("hogehoge\n", req.body)
   end
 


### PR DESCRIPTION
While the stripping of header values is required by RFC 2616 4.2 and
RFC 7230 3.2.4, the squishing is not and can break things, such as
when one header contains an HMAC of another header.

Fixes Ruby Bug 7021.