### PR TITLE
Enabled chunked encoding if Transfer-Encoding: chunked header is set

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -141,6 +141,7 @@ module WEBrick
     # Sets the response header +field+ to +value+
 
     def []=(field, value)
+      @chunked = value.to_s.downcase == 'chunked' if field.downcase == 'transfer-encoding'
       @header[field.downcase] = value.to_s
     end
 

--- a/test/webrick/test_httpresponse.rb
+++ b/test/webrick/test_httpresponse.rb
@@ -91,6 +91,13 @@ module WEBrick
       assert_equal 0, logger.messages.length
     end
 
+    def test_200_chunked_does_not_set_content_length
+      res.chunked     = false
+      res["Transfer-Encoding"] = 'chunked'
+      res.setup_header
+      assert_nil res.header.fetch('content-length', nil)
+    end
+
     def test_send_body_io
       IO.pipe {|body_r, body_w|
         body_w.write 'hello'


### PR DESCRIPTION
Patch from Leonard Garvey.

Fixes Ruby Bug 9986.