### PR TITLE
Allow WEBrick::HTTPServlet::CGIHandler :CGIInterpreter option to be array

### DIFF
--- a/lib/webrick/httpservlet/cgihandler.rb
+++ b/lib/webrick/httpservlet/cgihandler.rb
@@ -28,6 +28,7 @@ module WEBrick
     class CGIHandler < AbstractServlet
       Ruby = RbConfig.ruby # :nodoc:
       CGIRunner = "\"#{Ruby}\" \"#{WEBrick::Config::LIBDIR}/httpservlet/cgi_runner.rb\"" # :nodoc:
+      CGIRunnerArray = [Ruby, "#{WEBrick::Config::LIBDIR}/httpservlet/cgi_runner.rb".freeze].freeze # :nodoc:
 
       ##
       # Creates a new CGI script servlet for the script at +name+
@@ -36,7 +37,12 @@ module WEBrick
         super(server, name)
         @script_filename = name
         @tempdir = server[:TempDir]
-        @cgicmd = "#{CGIRunner} #{server[:CGIInterpreter]}"
+        interpreter = server[:CGIInterpreter]
+        if interpreter.is_a?(Array)
+          @cgicmd = CGIRunnerArray + interpreter
+        else
+          @cgicmd = "#{CGIRunner} #{interpreter}"
+        end
       end
 
       # :stopdoc:

--- a/test/webrick/test_filehandler.rb
+++ b/test/webrick/test_filehandler.rb
@@ -289,7 +289,7 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
     return if File.executable?(__FILE__) # skip on strange file system
 
     config = {
-      :CGIInterpreter => TestWEBrick::RubyBin,
+      :CGIInterpreter => TestWEBrick::RubyBinArray,
       :DocumentRoot => File.dirname(__FILE__),
       :CGIPathEnv => ENV['PATH'],
       :RequestCallback => Proc.new{|req, res|

--- a/test/webrick/utils.rb
+++ b/test/webrick/utils.rb
@@ -19,6 +19,8 @@ module TestWEBrick
     Ruby = EnvUtil.rubybin
     remove_const :CGIRunner
     CGIRunner = "\"#{Ruby}\" \"#{WEBrick::Config::LIBDIR}/httpservlet/cgi_runner.rb\"" # :nodoc:
+    remove_const :CGIRunnerArray
+    CGIRunnerArray = [Ruby, "#{WEBrick::Config::LIBDIR}/httpservlet/cgi_runner.rb"] # :nodoc:
   end
 
   RubyBin = "\"#{EnvUtil.rubybin}\""
@@ -26,6 +28,12 @@ module TestWEBrick
   RubyBin << " \"-I#{File.expand_path("../..", File.dirname(__FILE__))}/lib\""
   RubyBin << " \"-I#{File.dirname(EnvUtil.rubybin)}/.ext/common\""
   RubyBin << " \"-I#{File.dirname(EnvUtil.rubybin)}/.ext/#{RUBY_PLATFORM}\""
+
+  RubyBinArray = [EnvUtil.rubybin]
+  RubyBinArray << "--disable-gems"
+  RubyBinArray << "-I" << "#{File.expand_path("../..", File.dirname(__FILE__))}/lib"
+  RubyBinArray << "-I" << "#{File.dirname(EnvUtil.rubybin)}/.ext/common"
+  RubyBinArray << "-I" << "#{File.dirname(EnvUtil.rubybin)}/.ext/#{RUBY_PLATFORM}"
 
   require "test/unit" unless defined?(Test::Unit)
   include Test::Unit::Assertions


### PR DESCRIPTION
This way you don't need to escape each entry.

Implements Ruby Feature 15170.