### PR TITLE
WEBrick: prevent response splitting and header injection

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -394,7 +394,8 @@ module WEBrick
     private
 
     def check_header(header_value)
-      if header_value =~ /\r\n/
+      header_value = header_value.to_s
+      if /[\r\n]/ =~ header_value
         raise InvalidHeader
       else
         header_value

--- a/test/webrick/test_httpresponse.rb
+++ b/test/webrick/test_httpresponse.rb
@@ -29,7 +29,7 @@ module WEBrick
       @res.keep_alive  = true
     end
 
-    def test_prevent_response_splitting_headers
+    def test_prevent_response_splitting_headers_crlf
       res['X-header'] = "malicious\r\nCookie: hack"
       io = StringIO.new
       res.send_response io
@@ -39,8 +39,50 @@ module WEBrick
       refute_match 'hack', io.string
     end
 
-    def test_prevent_response_splitting_cookie_headers
+    def test_prevent_response_splitting_cookie_headers_crlf
       user_input = "malicious\r\nCookie: hack"
+      res.cookies << WEBrick::Cookie.new('author', user_input)
+      io = StringIO.new
+      res.send_response io
+      io.rewind
+      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
+      assert_equal '500', res.code
+      refute_match 'hack', io.string
+    end
+
+    def test_prevent_response_splitting_headers_cr
+      res['X-header'] = "malicious\rCookie: hack"
+      io = StringIO.new
+      res.send_response io
+      io.rewind
+      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
+      assert_equal '500', res.code
+      refute_match 'hack', io.string
+    end
+
+    def test_prevent_response_splitting_cookie_headers_cr
+      user_input = "malicious\rCookie: hack"
+      res.cookies << WEBrick::Cookie.new('author', user_input)
+      io = StringIO.new
+      res.send_response io
+      io.rewind
+      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
+      assert_equal '500', res.code
+      refute_match 'hack', io.string
+    end
+
+    def test_prevent_response_splitting_headers_lf
+      res['X-header'] = "malicious\nCookie: hack"
+      io = StringIO.new
+      res.send_response io
+      io.rewind
+      res = Net::HTTPResponse.read_new(Net::BufferedIO.new(io))
+      assert_equal '500', res.code
+      refute_match 'hack', io.string
+    end
+
+    def test_prevent_response_splitting_cookie_headers_lf
+      user_input = "malicious\nCookie: hack"
       res.cookies << WEBrick::Cookie.new('author', user_input)
       io = StringIO.new
       res.send_response io


### PR DESCRIPTION
This is a follow up to d9d4a28f1cdd05a0e8dabb36d747d40bbcc30f16.
The commit prevented CRLR, but did not address an isolated CR or an
isolated LF.

Co-Authored-By: NARUSE, Yui <naruse@airemix.jp>