### PR TITLE
Restore pretty logging

### DIFF
--- a/lib/webrick/accesslog.rb
+++ b/lib/webrick/accesslog.rb
@@ -149,7 +149,7 @@ module WEBrick
     # Escapes control characters in +data+
 
     def escape(data)
-      if data.tainted?
+      if RUBY_VERSION < '2.7' && data.tainted?
         data.gsub(/[[:cntrl:]\\]+/) {$&.dump[1...-1]}.untaint
       else
         data

--- a/lib/webrick/accesslog.rb
+++ b/lib/webrick/accesslog.rb
@@ -149,9 +149,11 @@ module WEBrick
     # Escapes control characters in +data+
 
     def escape(data)
-      data = data.gsub(/[[:cntrl:]\\]+/) {$&.dump[1...-1]}
-      data.untaint if RUBY_VERSION < '2.7'
-      data
+      if data.tainted?
+        data.gsub(/[[:cntrl:]\\]+/) {$&.dump[1...-1]}.untaint
+      else
+        data
+      end
     end
   end
 end


### PR DESCRIPTION
4c430f94 broke nicely printing untainted data which contains control sequences (newlines in particular), because the `.gsub()` is now always called, even when taint checking is not done. (This is not how the original code behaved.)

WEBrick logs the SSL certificate, which is a string containing newlines.

Before 4c430f94:

```
[2019-11-26 18:26:27] INFO
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            03:8d:93:d4:fd:52:36:be:5e:2c:89:26:de:26:5e:16:f6:7f
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C=US, O=Let's Encrypt, CN=Let's Encrypt Authority X3

...more output snipped
```

After 4c430f94:

```
[2019-11-26 18:46:43] INFO  \nCertificate:\n    Data:\n        Version: 3 (0x2)\n        Serial Number:\n            03:8d:93:d4:fd:52:36:be:5e:2c:89:26:de:26:5e:16:f6:7f\n        Signature Algorithm: sha256WithRSAEncryp
tion\n        Issuer: C=US, O=Let's Encrypt, CN=Let's Encrypt Authority X3\n

...more output snipped
```

I think there is a question of mixing "untainting" with "escaping control sequences" (regardless of where they come from).  Setting aside that question because it would be more complicated matter, I would like to restore the pretty logging.

@jeremyevans Any thoughts?