### PR TITLE
Extract creation of Net::HTTP in httpproxy

### DIFF
--- a/lib/webrick/httpproxy.rb
+++ b/lib/webrick/httpproxy.rb
@@ -295,6 +295,10 @@ module WEBrick
       return FakeProxyURI
     end
 
+    def create_net_http(uri, upstream)
+      Net::HTTP.new(uri.host, uri.port, upstream.host, upstream.port)
+    end
+
     def perform_proxy_request(req, res, req_class, body_stream = nil)
       uri = req.request_uri
       path = uri.path.dup
@@ -303,7 +307,7 @@ module WEBrick
       upstream = setup_upstream_proxy_authentication(req, res, header)
 
       body_tmp = []
-      http = Net::HTTP.new(uri.host, uri.port, upstream.host, upstream.port)
+      http = create_net_http(uri, upstream)
       req_fib = Fiber.new do
         http.start do
           if @config[:ProxyTimeout]


### PR DESCRIPTION
The "evil-proxy" gem [1] allows one to create an HTTPS man-in-the-middle proxy using webrick/httpproxy as the base.

It's a fairly unmaintained gem and therefore has fallen behind not-so-recent changes within webrick.

The biggest issue with e-p is its use of perform_proxy_request from webrick/httpproxy. Since httpproxy does not handle HTTPS requests in normal use the Net::HTTP object does not respect the fact that it might be used for that. Therefore evil-proxy basically has a cut/paste version of perform_proxy_request within it. So that means any changes to webrick require another cut-and-paste update to e-p.

I'd like to use e-p but I'd rather not cut-and-paste the method back in. Therefore I'm wondering if the following small patch would be acceptable. It simply moves the Net::HTTP.new call out into a distinct method which allows e-p to simply override that method to allow for use_ssl and verify_mode to be customized.

Thanks!

[1] - https://github.com/bbtfr/evil-proxy