### PR TITLE
Allow shutdown_pipe to be passed in via @config

### DIFF
--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -100,7 +100,7 @@ module WEBrick
       @logger.info("ruby #{rubyv}")
 
       @listeners = []
-      @shutdown_pipe = nil
+      @shutdown_pipe = @config[:ShutdownPipe]
       unless @config[:DoNotListen]
         if @config[:Listen]
           warn(":Listen option is deprecated; use GenericServer#listen", uplevel: 1)

--- a/test/webrick/test_server.rb
+++ b/test/webrick/test_server.rb
@@ -160,4 +160,16 @@ class TestWEBrickServer < Test::Unit::TestCase
       assert_join_threads([client_thread, server_thread])
     }
   end
+
+  def test_shutdown_pipe
+    pipe = IO.pipe
+    server = WEBrick::GenericServer.new(
+      :ShutdownPipe => pipe,
+      :BindAddress => '0.0.0.0',
+      :Port => 0,
+      :Logger => WEBrick::Log.new([], WEBrick::BasicLog::WARN))
+    server_thread = Thread.start { server.start }
+    pipe.last.puts('')
+    assert_join_threads([server_thread])
+  end
 end


### PR DESCRIPTION
I would like to be able to fork a webrick server and then shut it down from the parent process.

The @shutdown_pipe variable within webrick/server is the perfect tool for the job but it is not settable/accessible outside of the class. This patch simply allows for a pipe to be passed in via the server config.