### PR TITLE
Skip env-locale-sensitive CGI test on the "java" platform

### DIFF
--- a/test/webrick/test_cgi.rb
+++ b/test/webrick/test_cgi.rb
@@ -43,7 +43,7 @@ class TestWEBrickCGI < Test::Unit::TestCase
       http.request(req){|res| assert_equal("/path/info", res.body, log.call)}
       req = Net::HTTP::Get.new("/webrick.cgi/%3F%3F%3F?foo=bar")
       http.request(req){|res| assert_equal("/???", res.body, log.call)}
-      unless RUBY_PLATFORM =~ /mswin|mingw|cygwin|bccwin32/
+      unless RUBY_PLATFORM =~ /mswin|mingw|cygwin|bccwin32|java/
         # Path info of res.body is passed via ENV.
         # ENV[] returns different value on Windows depending on locale.
         req = Net::HTTP::Get.new("/webrick.cgi/%A4%DB%A4%B2/%A4%DB%A4%B2")


### PR DESCRIPTION
JRuby's environment variables are provided by the Java Development
Kit's (JDK's) classes, which present them as a map from string to
string. In order to do this, those environment variable names and
values must be decoded into characters, which breaks any variables
that are intended to be "raw" bytes not necessarily decodable with
the default system encoding.

This issue is detailed in jruby/jruby#6248. The only solution on
the JRuby side will be to bypass the JDK environment variable API
and go directly to the native getenv/setenv system calls. This is
not likely to happen in the near future, due to the complexity of
such a change and the rarity of undecodable environment values.

The exclude here was added due to the Windows platform also having
a similar sensitivity to character encodings when working with
environment variables. It seems appropriate to expand this skip
to the "java" platform, as the root issue is largely the same.