### PR TITLE
Do not use ensure in a block without begin

### DIFF
--- a/test/webrick/test_filehandler.rb
+++ b/test/webrick/test_filehandler.rb
@@ -104,82 +104,84 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
     bug2593 = '[ruby-dev:40030]'
 
     TestWEBrick.start_httpserver(config) do |server, addr, port, log|
-      server[:DocumentRootOptions][:NondisclosureName] = []
-      http = Net::HTTP.new(addr, port)
-      req = Net::HTTP::Get.new("/")
-      http.request(req){|res|
-        assert_equal("200", res.code, log.call)
-        assert_equal("text/html", res.content_type, log.call)
-        assert_match(/HREF="#{this_file}"/, res.body, log.call)
-      }
-      req = Net::HTTP::Get.new("/#{this_file}")
-      http.request(req){|res|
-        assert_equal("200", res.code, log.call)
-        assert_equal("text/plain", res.content_type, log.call)
-        assert_equal(this_data, res.body, log.call)
-      }
+      begin
+        server[:DocumentRootOptions][:NondisclosureName] = []
+        http = Net::HTTP.new(addr, port)
+        req = Net::HTTP::Get.new("/")
+        http.request(req){|res|
+          assert_equal("200", res.code, log.call)
+          assert_equal("text/html", res.content_type, log.call)
+          assert_match(/HREF="#{this_file}"/, res.body, log.call)
+        }
+        req = Net::HTTP::Get.new("/#{this_file}")
+        http.request(req){|res|
+          assert_equal("200", res.code, log.call)
+          assert_equal("text/plain", res.content_type, log.call)
+          assert_equal(this_data, res.body, log.call)
+        }
 
-      req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=#{filesize-100}-")
-      http.request(req){|res|
-        assert_equal("206", res.code, log.call)
-        assert_equal("text/plain", res.content_type, log.call)
-        assert_nothing_raised(bug2593) {range = res.content_range}
-        assert_equal((filesize-100)..(filesize-1), range, log.call)
-        assert_equal(this_data[-100..-1], res.body, log.call)
-      }
+        req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=#{filesize-100}-")
+        http.request(req){|res|
+          assert_equal("206", res.code, log.call)
+          assert_equal("text/plain", res.content_type, log.call)
+          assert_nothing_raised(bug2593) {range = res.content_range}
+          assert_equal((filesize-100)..(filesize-1), range, log.call)
+          assert_equal(this_data[-100..-1], res.body, log.call)
+        }
 
-      req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=-100")
-      http.request(req){|res|
-        assert_equal("206", res.code, log.call)
-        assert_equal("text/plain", res.content_type, log.call)
-        assert_nothing_raised(bug2593) {range = res.content_range}
-        assert_equal((filesize-100)..(filesize-1), range, log.call)
-        assert_equal(this_data[-100..-1], res.body, log.call)
-      }
+        req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=-100")
+        http.request(req){|res|
+          assert_equal("206", res.code, log.call)
+          assert_equal("text/plain", res.content_type, log.call)
+          assert_nothing_raised(bug2593) {range = res.content_range}
+          assert_equal((filesize-100)..(filesize-1), range, log.call)
+          assert_equal(this_data[-100..-1], res.body, log.call)
+        }
 
-      req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=0-99")
-      http.request(req){|res|
-        assert_equal("206", res.code, log.call)
-        assert_equal("text/plain", res.content_type, log.call)
-        assert_nothing_raised(bug2593) {range = res.content_range}
-        assert_equal(0..99, range, log.call)
-        assert_equal(this_data[0..99], res.body, log.call)
-      }
+        req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=0-99")
+        http.request(req){|res|
+          assert_equal("206", res.code, log.call)
+          assert_equal("text/plain", res.content_type, log.call)
+          assert_nothing_raised(bug2593) {range = res.content_range}
+          assert_equal(0..99, range, log.call)
+          assert_equal(this_data[0..99], res.body, log.call)
+        }
 
-      req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=100-199")
-      http.request(req){|res|
-        assert_equal("206", res.code, log.call)
-        assert_equal("text/plain", res.content_type, log.call)
-        assert_nothing_raised(bug2593) {range = res.content_range}
-        assert_equal(100..199, range, log.call)
-        assert_equal(this_data[100..199], res.body, log.call)
-      }
+        req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=100-199")
+        http.request(req){|res|
+          assert_equal("206", res.code, log.call)
+          assert_equal("text/plain", res.content_type, log.call)
+          assert_nothing_raised(bug2593) {range = res.content_range}
+          assert_equal(100..199, range, log.call)
+          assert_equal(this_data[100..199], res.body, log.call)
+        }
 
-      req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=0-0")
-      http.request(req){|res|
-        assert_equal("206", res.code, log.call)
-        assert_equal("text/plain", res.content_type, log.call)
-        assert_nothing_raised(bug2593) {range = res.content_range}
-        assert_equal(0..0, range, log.call)
-        assert_equal(this_data[0..0], res.body, log.call)
-      }
+        req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=0-0")
+        http.request(req){|res|
+          assert_equal("206", res.code, log.call)
+          assert_equal("text/plain", res.content_type, log.call)
+          assert_nothing_raised(bug2593) {range = res.content_range}
+          assert_equal(0..0, range, log.call)
+          assert_equal(this_data[0..0], res.body, log.call)
+        }
 
-      req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=-1")
-      http.request(req){|res|
-        assert_equal("206", res.code, log.call)
-        assert_equal("text/plain", res.content_type, log.call)
-        assert_nothing_raised(bug2593) {range = res.content_range}
-        assert_equal((filesize-1)..(filesize-1), range, log.call)
-        assert_equal(this_data[-1, 1], res.body, log.call)
-      }
+        req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=-1")
+        http.request(req){|res|
+          assert_equal("206", res.code, log.call)
+          assert_equal("text/plain", res.content_type, log.call)
+          assert_nothing_raised(bug2593) {range = res.content_range}
+          assert_equal((filesize-1)..(filesize-1), range, log.call)
+          assert_equal(this_data[-1, 1], res.body, log.call)
+        }
 
-      req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=0-0, -2")
-      http.request(req){|res|
-        assert_equal("206", res.code, log.call)
-        assert_equal("multipart/byteranges", res.content_type, log.call)
-      }
-    ensure
-      server[:DocumentRootOptions].delete :NondisclosureName
+        req = Net::HTTP::Get.new("/#{this_file}", "range"=>"bytes=0-0, -2")
+        http.request(req){|res|
+          assert_equal("206", res.code, log.call)
+          assert_equal("multipart/byteranges", res.content_type, log.call)
+        }
+      ensure
+        server[:DocumentRootOptions].delete :NondisclosureName
+      end
     end
   end
 


### PR DESCRIPTION
This syntax is not supported until Ruby 2.5, and Webrick still
targets Ruby 2.3+.