### PR TITLE
Allow empty POST and PUT requests without content length

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -522,7 +522,7 @@ module WEBrick
         if @remaining_size > 0 && @socket.eof?
           raise HTTPStatus::BadRequest, "invalid body size."
         end
-      elsif BODY_CONTAINABLE_METHODS.member?(@request_method)
+      elsif BODY_CONTAINABLE_METHODS.member?(@request_method) && !@socket.eof
         raise HTTPStatus::LengthRequired
       end
       return @body

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -425,6 +425,18 @@ GET /
     assert_equal l, msg.size
   end
 
+  def test_empty_post
+    msg = <<-_end_of_message_
+      POST /path?foo=x;foo=y;foo=z;bar=1 HTTP/1.1
+      Host: test.ruby-lang.org:8080
+      Content-Type: application/x-www-form-urlencoded
+
+    _end_of_message_
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
+    req.body
+  end
+
   def test_bad_messages
     param = "foo=1;foo=2;foo=3;bar=x"
     msg = <<-_end_of_message_


### PR DESCRIPTION
RFC 7230 section 3.3.3 allows for this.

Fixes #30