### PR TITLE
Only run test_big_bodies test on Ruby 2.5+

### DIFF
--- a/test/webrick/test_httpproxy.rb
+++ b/test/webrick/test_httpproxy.rb
@@ -213,7 +213,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
         end
       end
     end
-  end
+  end if RUBY_VERSION >= '2.5'
 
   def test_http10_proxy_chunked
     # Testing HTTP/1.0 client request and HTTP/1.1 chunked response


### PR DESCRIPTION
It was added after Ruby 2.5, and it looks like it never ran correctly
on Ruby <2.5.