### PR TITLE
Fix shutdown_pipe test issue

### DIFF
--- a/test/webrick/test_server.rb
+++ b/test/webrick/test_server.rb
@@ -162,14 +162,25 @@ class TestWEBrickServer < Test::Unit::TestCase
   end
 
   def test_shutdown_pipe
-    pipe = IO.pipe
-    server = WEBrick::GenericServer.new(
-      :ShutdownPipe => pipe,
-      :BindAddress => '0.0.0.0',
-      :Port => 0,
-      :Logger => WEBrick::Log.new([], WEBrick::BasicLog::WARN))
-    server_thread = Thread.start { server.start }
-    pipe.last.puts('')
-    assert_join_threads([server_thread])
+    loop_count = 0
+    server_threads = []
+    loop do
+      loop_count += 1
+      break if loop_count == 11
+
+      pipe = IO.pipe
+      server = WEBrick::GenericServer.new(
+        :ShutdownPipe => pipe,
+        :BindAddress => '0.0.0.0',
+        :Port => 0,
+        :Logger => WEBrick::Log.new([], WEBrick::BasicLog::WARN))
+      server_threads << Thread.start { server.start }
+      sleep 0.1 until server.status == :Running || !server_threads.last.status
+      if server_threads.last.status
+        pipe.last.puts('')
+        break
+      end
+    end
+    assert_join_threads(server_threads)
   end
 end


### PR DESCRIPTION
This addresses the test issue from #44. It appears the issue is that the server aborts for an unknown reason. There is no other way the pipe could be closed when the attempt to write to it occurs.

Looking at the test directly above the new one https://github.com/ruby/webrick/blob/1daacc18490cbc96bcf1bdc741f3ccff65a0d164/test/webrick/test_server.rb#L151-L161- it appears that it assumes that a server may not start properly and simply appears to skip the test if the server fails to start. The only way on line 156 that the thread status is a falsy value is if the thread is already dead when it is examined. That would imply the server is non-existent at that point.

The fix tries 10 times to bring up a server and if it fails to do so - it continues on.