### PR TITLE
Ensure server port numbers are numeric and ensure they are stored as …

### DIFF
--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -102,6 +102,9 @@ module WEBrick
       @listeners = []
       @shutdown_pipe = @config[:ShutdownPipe]
       unless @config[:DoNotListen]
+        raise ArgumentError, "Port must an integer" unless @config[:Port].to_s == @config[:Port].to_i.to_s
+
+        @config[:Port] = @config[:Port].to_i
         if @config[:Listen]
           warn(":Listen option is deprecated; use GenericServer#listen", uplevel: 1)
         end


### PR DESCRIPTION
…integers

When passing in a "0" for the port number - the port number is not updated as is the intention. Ensuring the port number is stored as an integer solves this.