### PR TITLE
Refix test_shutdown_pipe

### DIFF
--- a/test/webrick/test_server.rb
+++ b/test/webrick/test_server.rb
@@ -176,9 +176,13 @@ class TestWEBrickServer < Test::Unit::TestCase
         :Logger => WEBrick::Log.new([], WEBrick::BasicLog::WARN))
       server_threads << Thread.start { server.start }
       sleep 0.1 until server.status == :Running || !server_threads.last.status
-      if server_threads.last.status
-        pipe.last.puts('')
-        break
+      begin
+        if server_threads.last.status
+          pipe.last.puts('')
+          break
+        end
+      rescue IOError
+        nil
       end
     end
     assert_join_threads(server_threads)


### PR DESCRIPTION
As mentioned in #44 and #54 - there continues to be issues with regards to the server startup with regards to this test. WEBrick::GenericServer#stop swallows an IOError internally - so the fix here is to swallow the error during the test and to retry.