### PR TITLE
Use frozen strings

### DIFF
--- a/lib/webrick/accesslog.rb
+++ b/lib/webrick/accesslog.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # accesslog.rb -- Access log handling utilities
 #

--- a/lib/webrick/cgi.rb
+++ b/lib/webrick/cgi.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # cgi.rb -- Yet another CGI library
 #

--- a/lib/webrick/compat.rb
+++ b/lib/webrick/compat.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # compat.rb -- cross platform compatibility
 #

--- a/lib/webrick/config.rb
+++ b/lib/webrick/config.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # config.rb -- Default configurations.
 #

--- a/lib/webrick/cookie.rb
+++ b/lib/webrick/cookie.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # cookie.rb -- Cookie class
 #
@@ -92,7 +92,7 @@ module WEBrick
     # The cookie string suitable for use in an HTTP header
 
     def to_s
-      ret = ""
+      ret = +""
       ret << @name << "=" << @value
       ret << "; " << "Version=" << @version.to_s if @version > 0
       ret << "; " << "Domain="  << @domain  if @domain

--- a/lib/webrick/htmlutils.rb
+++ b/lib/webrick/htmlutils.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # htmlutils.rb -- HTMLUtils Module
 #

--- a/lib/webrick/httpauth.rb
+++ b/lib/webrick/httpauth.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpauth.rb -- HTTP access authentication
 #

--- a/lib/webrick/httpauth/authenticator.rb
+++ b/lib/webrick/httpauth/authenticator.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # httpauth/authenticator.rb -- Authenticator mix-in module.
 #

--- a/lib/webrick/httpauth/basicauth.rb
+++ b/lib/webrick/httpauth/basicauth.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpauth/basicauth.rb -- HTTP basic access authentication
 #

--- a/lib/webrick/httpauth/digestauth.rb
+++ b/lib/webrick/httpauth/digestauth.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpauth/digestauth.rb -- HTTP digest access authentication
 #

--- a/lib/webrick/httpauth/htdigest.rb
+++ b/lib/webrick/httpauth/htdigest.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpauth/htdigest.rb -- Apache compatible htdigest file
 #

--- a/lib/webrick/httpauth/htgroup.rb
+++ b/lib/webrick/httpauth/htgroup.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpauth/htgroup.rb -- Apache compatible htgroup file
 #

--- a/lib/webrick/httpauth/htpasswd.rb
+++ b/lib/webrick/httpauth/htpasswd.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpauth/htpasswd -- Apache compatible htpasswd file
 #

--- a/lib/webrick/httpauth/userdb.rb
+++ b/lib/webrick/httpauth/userdb.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # httpauth/userdb.rb -- UserDB mix-in module.
 #

--- a/lib/webrick/httpproxy.rb
+++ b/lib/webrick/httpproxy.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpproxy.rb -- HTTPProxy Class
 #

--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httprequest.rb -- HTTPRequest Class
 #
@@ -171,7 +171,7 @@ module WEBrick
       @accept_charset = []
       @accept_encoding = []
       @accept_language = []
-      @body = ""
+      @body = +""
 
       @addr = @peeraddr = nil
       @attributes = {}

--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpresponse.rb -- HTTPResponse Class
 #
@@ -332,7 +332,7 @@ module WEBrick
 
     def send_header(socket) # :nodoc:
       if @http_version.major > 0
-        data = status_line()
+        data = status_line().dup
         @header.each{|key, value|
           tmp = key.gsub(/\bwww|^te$|\b\w/){ $&.upcase }
           data << "#{tmp}: #{check_header(value)}" << CRLF
@@ -419,7 +419,7 @@ module WEBrick
     # :stopdoc:
 
     def error_body(backtrace, ex, host, port)
-      @body = ''
+      @body = +''
       @body << <<-_end_of_html_
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
 <HTML>
@@ -453,11 +453,11 @@ module WEBrick
         if @request_method == "HEAD"
           # do nothing
         elsif chunked?
-          buf  = ''
+          buf = +''
           begin
             @body.readpartial(@buffer_size, buf)
             size = buf.bytesize
-            data = "#{size.to_s(16)}#{CRLF}#{buf}#{CRLF}"
+            data = +"#{size.to_s(16)}#{CRLF}#{buf}#{CRLF}"
             socket.write(data)
             data.clear
             @sent_size += size
@@ -539,7 +539,7 @@ module WEBrick
         socket = @socket
         @resp.instance_eval {
           size = buf.bytesize
-          data = "#{size.to_s(16)}#{CRLF}#{buf}#{CRLF}"
+          data = +"#{size.to_s(16)}#{CRLF}#{buf}#{CRLF}"
           socket.write(data)
           data.clear
           @sent_size += size

--- a/lib/webrick/https.rb
+++ b/lib/webrick/https.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # https.rb -- SSL/TLS enhancement for HTTPServer
 #

--- a/lib/webrick/httpserver.rb
+++ b/lib/webrick/httpserver.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpserver.rb -- HTTPServer Class
 #
@@ -285,7 +285,7 @@ module WEBrick
       end
 
       def normalize(dir)
-        ret = dir ? dir.dup : ""
+        ret = dir ? dir.dup : +""
         ret.sub!(%r|/+\z|, "")
         ret
       end

--- a/lib/webrick/httpservlet.rb
+++ b/lib/webrick/httpservlet.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpservlet.rb -- HTTPServlet Utility File
 #

--- a/lib/webrick/httpservlet/abstract.rb
+++ b/lib/webrick/httpservlet/abstract.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httpservlet.rb -- HTTPServlet Module
 #

--- a/lib/webrick/httpservlet/cgi_runner.rb
+++ b/lib/webrick/httpservlet/cgi_runner.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # cgi_runner.rb -- CGI launcher.
 #
@@ -10,7 +10,7 @@
 # $IPR: cgi_runner.rb,v 1.9 2002/09/25 11:33:15 gotoyuzo Exp $
 
 def sysread(io, size)
-  buf = ""
+  buf = +""
   while size > 0
     tmp = io.sysread(size)
     buf << tmp

--- a/lib/webrick/httpservlet/cgihandler.rb
+++ b/lib/webrick/httpservlet/cgihandler.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # cgihandler.rb -- CGIHandler Class
 #

--- a/lib/webrick/httpservlet/erbhandler.rb
+++ b/lib/webrick/httpservlet/erbhandler.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # erbhandler.rb -- ERBHandler Class
 #

--- a/lib/webrick/httpservlet/filehandler.rb
+++ b/lib/webrick/httpservlet/filehandler.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # filehandler.rb -- FileHandler Module
 #
@@ -481,9 +481,9 @@ module WEBrick
         elsif !namewidth or (namewidth = namewidth.to_i) < 2
           namewidth = 25
         end
-        query = query.inject('') {|s, (k, v)| s << '&' << HTMLUtils::escape("#{k}=#{v}")}
+        query = query.inject('') {|s, (k, v)| s << '&' << HTMLUtils::escape("#{k}=#{v}")}.dup
 
-        type = "text/html"
+        type = +"text/html"
         case enc = Encoding.find('filesystem')
         when Encoding::US_ASCII, Encoding::ASCII_8BIT
         else
@@ -492,7 +492,7 @@ module WEBrick
         res['content-type'] = type
 
         title = "Index of #{HTMLUtils::escape(req.path)}"
-        res.body = <<-_end_of_html_
+        res.body = +<<-_end_of_html_
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <HTML>
   <HEAD>
@@ -528,7 +528,7 @@ module WEBrick
           else
             dname = name
           end
-          s =  "<TR><TD class=\"name\"><A HREF=\"#{HTTPUtils::escape(name)}#{query if name.end_with?('/')}\">#{HTMLUtils::escape(dname)}</A></TD>"
+          s =  +"<TR><TD class=\"name\"><A HREF=\"#{HTTPUtils::escape(name)}#{query if name.end_with?('/')}\">#{HTMLUtils::escape(dname)}</A></TD>"
           s << "<TD class=\"mtime\">" << (time ? time.strftime("%Y/%m/%d %H:%M") : "") << "</TD>"
           s << "<TD class=\"size\">" << (size >= 0 ? size.to_s : "-") << "</TD></TR>\n"
           res.body << s

--- a/lib/webrick/httpservlet/prochandler.rb
+++ b/lib/webrick/httpservlet/prochandler.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # prochandler.rb -- ProcHandler Class
 #

--- a/lib/webrick/httpstatus.rb
+++ b/lib/webrick/httpstatus.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # httpstatus.rb -- HTTPStatus Class
 #

--- a/lib/webrick/httputils.rb
+++ b/lib/webrick/httputils.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # httputils.rb -- HTTPUtils Module
 #
@@ -231,7 +231,7 @@ module WEBrick
     # Quotes and escapes quotes in +str+
 
     def quote(str)
-      '"' << str.gsub(/[\\\"]/o, "\\\1") << '"'
+      +'"' << str.gsub(/[\\\"]/o, "\\\1") << '"'
     end
     module_function :quote
 
@@ -495,7 +495,7 @@ module WEBrick
     # Escapes path +str+
 
     def escape_path(str)
-      result = ""
+      result = +""
       str.scan(%r{/([^/]*)}).each{|i|
         result << "/" << _escape(i[0], UNESCAPED_PCHAR)
       }

--- a/lib/webrick/httpversion.rb
+++ b/lib/webrick/httpversion.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # HTTPVersion.rb -- presentation of HTTP version
 #

--- a/lib/webrick/log.rb
+++ b/lib/webrick/log.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # log.rb -- Log Class
 #
@@ -86,15 +86,15 @@ module WEBrick
     end
 
     # Shortcut for logging a FATAL message
-    def fatal(msg) log(FATAL, "FATAL " << format(msg)); end
+    def fatal(msg) log(FATAL, "FATAL " + format(msg)); end
     # Shortcut for logging an ERROR message
-    def error(msg) log(ERROR, "ERROR " << format(msg)); end
+    def error(msg) log(ERROR, "ERROR " + format(msg)); end
     # Shortcut for logging a WARN message
-    def warn(msg)  log(WARN,  "WARN  " << format(msg)); end
+    def warn(msg)  log(WARN,  "WARN  " + format(msg)); end
     # Shortcut for logging an INFO message
-    def info(msg)  log(INFO,  "INFO  " << format(msg)); end
+    def info(msg)  log(INFO,  "INFO  " + format(msg)); end
     # Shortcut for logging a DEBUG message
-    def debug(msg) log(DEBUG, "DEBUG " << format(msg)); end
+    def debug(msg) log(DEBUG, "DEBUG " + format(msg)); end
 
     # Will the logger output FATAL messages?
     def fatal?; @level >= FATAL; end
@@ -118,7 +118,7 @@ module WEBrick
     # * Otherwise it will return +arg+.inspect.
     def format(arg)
       if arg.is_a?(Exception)
-        "#{arg.class}: #{AccessLog.escape(arg.message)}\n\t" <<
+        +"#{arg.class}: #{AccessLog.escape(arg.message)}\n\t" <<
         arg.backtrace.join("\n\t") << "\n"
       elsif arg.respond_to?(:to_str)
         AccessLog.escape(arg.to_str)

--- a/lib/webrick/server.rb
+++ b/lib/webrick/server.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # server.rb -- GenericServer Class
 #

--- a/lib/webrick/ssl.rb
+++ b/lib/webrick/ssl.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # ssl.rb -- SSL/TLS enhancement for GenericServer
 #

--- a/lib/webrick/utils.rb
+++ b/lib/webrick/utils.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # utils.rb -- Miscellaneous utilities
 #
@@ -78,7 +78,7 @@ module WEBrick
     # Generates a random string of length +len+
     def random_string(len)
       rand_max = RAND_CHARS.bytesize
-      ret = ""
+      ret = +""
       len.times{ ret << RAND_CHARS[rand(rand_max)] }
       ret
     end

--- a/lib/webrick/version.rb
+++ b/lib/webrick/version.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # version.rb -- version and release date
 #


### PR DESCRIPTION
This PR ports https://github.com/ruby/ruby/pull/3560 to this repo.

`frozen_string_literal: true` is a generally a good practice, and here it will make it easier to call some building blocks of WEBricks from places that require objects to be frozen (e.g. Ractor).

cc @jeremyevans 