### PR TITLE
More rubies on CI, deprecating ruby 2.3 due to test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 2.7, 2.6, 2.5, head ]
+        ruby: [ 3.0, 2.7, 2.6, 2.5, 2.4, 2.3, head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.0, 2.7, 2.6, 2.5, 2.4, 2.3, head ]
+        ruby: [ "3.0", 2.7, 2.6, 2.5, 2.4, head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/webrick.gemspec
+++ b/webrick.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
     "lib/webrick/version.rb",
     "webrick.gemspec",
   ]
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.4.0"
 
   s.authors = ["TAKAHASHI Masayoshi", "GOTOU YUUZOU", "Eric Wong"]
   s.email = [nil, nil, 'normal@ruby-lang.org']


### PR DESCRIPTION
ruby 2.3 now raise an ArgumentError while running tests

```
 ........E
===============================================================================
Error: test_slow_connect(TestWEBrickSSLServer): ArgumentError: wrong number of arguments (given 3, expected 1..2)
/opt/hostedtoolcache/Ruby/2.3.8/x64/lib/ruby/2.3.0/timeout.rb:73:in `timeout'
/home/runner/work/webrick/webrick/test/lib/envutil.rb:72:in `timeout'
/home/runner/work/webrick/webrick/test/webrick/test_ssl_server.rb:58:in `test_slow_connect'
     55:       :SSLEnable => true,
     56:       :SSLCertName => "/C=JP/O=www.ruby-lang.org/CN=Ruby",
     57:     }
  => 58:     EnvUtil.timeout(10) do
     59:       TestWEBrick.start_server(Echo, config) do |server, addr, port, log|
     60:         outer = TCPSocket.new(addr, port)
     61:         inner = TCPSocket.new(addr, port)
===============================================================================
```

making 2.4 the minimum and including 3.0 as base ruby
