### PR TITLE
add mime type for .webmanifest extension

### DIFF
--- a/lib/webrick/httputils.rb
+++ b/lib/webrick/httputils.rb
@@ -104,6 +104,7 @@ module WEBrick
       "txt"   => "text/plain",
       "wasm"  => "application/wasm",
       "webm"  => "video/webm",
+      "webmanifest" => "application/manifest+json",
       "webp"  => "image/webp",
       "woff"  => "font/woff",
       "woff2" => "font/woff2",


### PR DESCRIPTION
This PR adds a MIME type for the Web Application Manifest standard.

https://developer.mozilla.org/en-US/docs/Web/Manifest#deploying_a_manifest_with_the_link_tag
https://w3c.github.io/manifest/#media-type-registration