### PR TITLE
Fix invalid use of IP addresses in SNI

### DIFF
--- a/test/webrick/test_httpproxy.rb
+++ b/test/webrick/test_httpproxy.rb
@@ -282,7 +282,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
     #    3.   ------- GET or POST ---------->
     #
     key = TEST_KEY_RSA2048
-    cert = make_certificate(key, "127.0.0.1")
+    cert = make_certificate(key, "localhost")
     s_config = {
       :SSLEnable =>true,
       :ServerName => "localhost",
@@ -300,7 +300,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
         res.body = "SSL #{req.request_method} #{req.path} #{req.body}"
       }
       TestWEBrick.start_httpproxy(config){|server, addr, port, log|
-        http = Net::HTTP.new("127.0.0.1", s_port, addr, port)
+        http = Net::HTTP.new("localhost", s_port, addr, port)
         http.use_ssl = true
         http.verify_callback = Proc.new do |preverify_ok, store_ctx|
           store_ctx.current_cert.to_der == cert.to_der
@@ -398,7 +398,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
           #    3.   ---------- GET or POST -------------->
           #
           key = TEST_KEY_RSA2048
-          cert = make_certificate(key, "127.0.0.1")
+          cert = make_certificate(key, "localhost")
           s_config = {
             :SSLEnable =>true,
             :ServerName => "localhost",
@@ -409,7 +409,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
             s_server.mount_proc("/"){|req2, res|
               res.body = "SSL #{req2.request_method} #{req2.path} #{req2.body}"
             }
-            http = Net::HTTP.new("127.0.0.1", s_port, addr, port, up_log.call + log.call + s_log.call)
+            http = Net::HTTP.new("localhost", s_port, addr, port, up_log.call + log.call + s_log.call)
             http.use_ssl = true
             http.verify_callback = Proc.new do |preverify_ok, store_ctx|
               store_ctx.current_cert.to_der == cert.to_der

--- a/test/webrick/test_https.rb
+++ b/test/webrick/test_https.rb
@@ -17,6 +17,11 @@ class TestWEBrickHTTPS < Test::Unit::TestCase
   class HTTPSNITest < ::Net::HTTP
     attr_accessor :sni_hostname
 
+    def connect
+      @address = 'localhost' if @address == '127.0.0.1'
+      super
+    end
+
     def ssl_socket_connect(s, timeout)
       s.hostname = sni_hostname
       super


### PR DESCRIPTION
Server Name Indication does not allow IP addresses (RFC 6066, section 3:
`Literal IPv4 and IPv6 addresses are not permitted in "HostName".`).

Recent versions of LibreSSL enforce this requirement, and the tests
currently break when running on such versions.  Use localhost
instead of 127.0.0.1 to avoid the issue.  This requires adding
HTTPSNITest#connect, because s.hostname= is called before
ssl_socket_connect.