### PR TITLE
Switch to URI.parse to parse httprequest host line.

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -488,17 +488,18 @@ module WEBrick
       str.sub!(%r{\A/+}o, '/')
       uri = URI::parse(str)
       return uri if uri.absolute?
+      uri.scheme = @forwarded_proto || scheme
       if @forwarded_host
         host, port = @forwarded_host, @forwarded_port
       elsif self["host"]
-        pattern = /\A(#{URI::REGEXP::PATTERN::HOST})(?::(\d+))?\z/n
-        host, port = *self['host'].scan(pattern)[0]
+        host_uri = URI.parse("#{uri.scheme}://#{self["host"]}")
+        host = host_uri.host
+        port = host_uri.port
       elsif @addr.size > 0
         host, port = @addr[2], @addr[1]
       else
         host, port = @config[:ServerName], @config[:Port]
       end
-      uri.scheme = @forwarded_proto || scheme
       uri.host = host
       uri.port = port ? port.to_i : nil
       return URI::parse(uri.to_s)

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -196,6 +196,29 @@ GET /
                  req.request_uri)
     assert_equal("[fe80::208:dff:feef:98c7]", req.host)
     assert_equal(8080, req.port)
+
+    msg = <<-_end_of_message_
+      GET /path HTTP/1.1
+      Host: a_b.example.com
+
+    _end_of_message_
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
+    assert_equal(URI.parse("http://a_b.example.com/path"),
+                 req.request_uri)
+    assert_equal("a_b.example.com", req.host)
+    assert_equal(80, req.port)
+    msg = <<-_end_of_message_
+      GET /path HTTP/1.1
+      Host: a_b.example.com:8080
+
+    _end_of_message_
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    req.parse(StringIO.new(msg.gsub(/^ {6}/, "")))
+    assert_equal(URI.parse("http://a_b.example.com:8080/path"),
+                 req.request_uri)
+    assert_equal("a_b.example.com", req.host)
+    assert_equal(8080, req.port)
   end
 
   def test_parse_get_params


### PR DESCRIPTION
This solves the issue of the use of underscores in a host name. Using URI.parse makes us consistent with its functionality.