### PR TITLE
Move the host request parsing to a separate method.

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -488,20 +488,24 @@ module WEBrick
       str.sub!(%r{\A/+}o, '/')
       uri = URI::parse(str)
       return uri if uri.absolute?
+      uri.scheme = @forwarded_proto || scheme
       if @forwarded_host
         host, port = @forwarded_host, @forwarded_port
       elsif self["host"]
-        pattern = /\A(#{URI::REGEXP::PATTERN::HOST})(?::(\d+))?\z/n
-        host, port = *self['host'].scan(pattern)[0]
+        host, port = parse_host_request_line(self["host"], uri.scheme)
       elsif @addr.size > 0
         host, port = @addr[2], @addr[1]
       else
         host, port = @config[:ServerName], @config[:Port]
       end
-      uri.scheme = @forwarded_proto || scheme
       uri.host = host
       uri.port = port ? port.to_i : nil
       return URI::parse(uri.to_s)
+    end
+
+    def parse_host_request_line(host, _scheme)
+      pattern = /\A(#{URI::REGEXP::PATTERN::HOST})(?::(\d+))?\z/no
+      host.scan(pattern)[0]
     end
 
     def read_body(socket, block)

--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -488,22 +488,22 @@ module WEBrick
       str.sub!(%r{\A/+}o, '/')
       uri = URI::parse(str)
       return uri if uri.absolute?
-      uri.scheme = @forwarded_proto || scheme
       if @forwarded_host
         host, port = @forwarded_host, @forwarded_port
       elsif self["host"]
-        host, port = parse_host_request_line(self["host"], uri.scheme)
+        host, port = parse_host_request_line(self["host"])
       elsif @addr.size > 0
         host, port = @addr[2], @addr[1]
       else
         host, port = @config[:ServerName], @config[:Port]
       end
+      uri.scheme = @forwarded_proto || scheme
       uri.host = host
       uri.port = port ? port.to_i : nil
       return URI::parse(uri.to_s)
     end
 
-    def parse_host_request_line(host, _scheme)
+    def parse_host_request_line(host)
       pattern = /\A(#{URI::REGEXP::PATTERN::HOST})(?::(\d+))?\z/no
       host.scan(pattern)[0]
     end


### PR DESCRIPTION
Allows for someone to override the parsing to accommodate "alternatives".
One could write the following to allow underscores in host names.

```
require 'webrick/httprequest'

module WEBrick
  class HTTPRequest
    private

    def parse_host_request_line(host)
      uri = URI.parse("scheme://#{host}")
      [uri.host, uri.port]
    end
  end
end
```
Also adding the "o" option to the regex so the regex is only built once.``