### PR TITLE
Catch CONNRESET on `eof?`

### DIFF
--- a/lib/webrick/cgi.rb
+++ b/lib/webrick/cgi.rb
@@ -259,6 +259,8 @@ module WEBrick
 
       def eof?
         input.eof?
+      rescue Errno::ECONNRESET
+        true
       end
 
       def <<(data)


### PR DESCRIPTION
Some clients (`wget`) resets the TCP connection when 404 is received, webrick then logs:

```
::1 - - [18/Jan/2022:12:41:41 CET] "GET /404 HTTP/1.1" 404 7173
- -> /404
[2022-01-18 12:41:41] ERROR Errno::ECONNRESET: Connection reset by peer @ io_fillbuf - fd:9
        /home/carl/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webrick-1.7.0/lib/webrick/httpserver.rb:82:in `eof?'
        /home/carl/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webrick-1.7.0/lib/webrick/httpserver.rb:82:in `run'
        /home/carl/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webrick-1.7.0/lib/webrick/server.rb:310:in `block in start_thread'
```

![Screenshot from 2022-01-18 12-43-23](https://user-images.githubusercontent.com/180046/149931375-e9063b75-5ae6-448a-8b44-df8a5097f96d.png)

