### PR TITLE
Only output prime information to $stderr if $VERBOSE

### DIFF
--- a/lib/webrick/ssl.rb
+++ b/lib/webrick/ssl.rb
@@ -95,18 +95,22 @@ module WEBrick
     # the issuer +cn+ and a +comment+ to be stored in the certificate.
 
     def create_self_signed_cert(bits, cn, comment)
-      rsa = OpenSSL::PKey::RSA.new(bits){|p, n|
-        case p
-        when 0; $stderr.putc "."  # BN_generate_prime
-        when 1; $stderr.putc "+"  # BN_generate_prime
-        when 2; $stderr.putc "*"  # searching good prime,
-                                  # n = #of try,
-                                  # but also data from BN_generate_prime
-        when 3; $stderr.putc "\n" # found good prime, n==0 - p, n==1 - q,
-                                  # but also data from BN_generate_prime
-        else;   $stderr.putc "*"  # BN_generate_prime
-        end
-      }
+      rsa = if $VERBOSE
+        OpenSSL::PKey::RSA.new(bits){|p, n|
+          case p
+          when 0; $stderr.putc "."  # BN_generate_prime
+          when 1; $stderr.putc "+"  # BN_generate_prime
+          when 2; $stderr.putc "*"  # searching good prime,
+                                    # n = #of try,
+                                    # but also data from BN_generate_prime
+          when 3; $stderr.putc "\n" # found good prime, n==0 - p, n==1 - q,
+                                    # but also data from BN_generate_prime
+          else;   $stderr.putc "*"  # BN_generate_prime
+          end
+        }
+      else
+        OpenSSL::PKey::RSA.new(bits)
+      end
       cert = OpenSSL::X509::Certificate.new
       cert.version = 2
       cert.serial = 1


### PR DESCRIPTION
This is currently done even in non-$VERBOSE mode.  My guess as to
the reason it is done is to give the user the impression that the
server is doing something and not frozen, but I still think there
should be a way to disable it.  If the $VERBOSE flag isn't a good
way to do that, let's offer some other way to do that.