### PR TITLE
remove unneeded bin/console and bin/setup files from gemspec

### DIFF
--- a/webrick.gemspec
+++ b/webrick.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "README.md",
     "Rakefile",
-    "bin/console",
-    "bin/setup",
     "lib/webrick.rb",
     "lib/webrick/accesslog.rb",
     "lib/webrick/cgi.rb",


### PR DESCRIPTION
I'm currently (trying)[https://github.com/void-linux/void-packages/pull/31003] to package this for void, and have discovered that the `bin/console` and `bin/setup` files are included in the gemspec, and would be installed in the system `/usr/bin` directory when trying to install this package system-wide. My understanding is that these binaries are useful for development on `webrick` only, and should not be packaged, but I'm not familiar with ruby at all and could be wrong here.