### PR TITLE
Better support for connection upgrade and bi-directional streaming.

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -110,12 +110,6 @@ module WEBrick
 
     attr_accessor :upgrade
 
-    def upgrade!(protocol)
-      @upgrade = protocol
-      @keep_alive = false
-      @chunked = false
-    end
-
     ##
     # Creates a new HTTP response object.  WEBrick::Config::HTTP is the
     # default configuration.
@@ -226,6 +220,16 @@ module WEBrick
 
     def keep_alive?
       @keep_alive
+    end
+
+    ##
+    # Sets the response to be a streaming/upgrade response.
+    # This will disable keep-alive and chunked transfer encoding.
+
+    def upgrade!(protocol)
+      @upgrade = protocol
+      @keep_alive = false
+      @chunked = false
     end
 
     ##

--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -546,7 +546,9 @@ module WEBrick
           @body.call(socket)
         end
 
-        @sent_size = @header['content-length'].to_i
+        if content_length = @header['content-length']
+          @sent_size = content_length.to_i
+        end
       end
     end
 

--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -292,7 +292,7 @@ module WEBrick
         @header.delete('content-length')
       elsif @header['content-length'].nil?
         if @body.respond_to?(:bytesize)
-          @header['content-length'] = (@body ? @body.bytesize : 0).to_s
+          @header['content-length'] = @body.bytesize.to_s
         else
           @header['connection'] = 'close'
         end

--- a/test/webrick/test_httpserver.rb
+++ b/test/webrick/test_httpserver.rb
@@ -377,8 +377,7 @@ class TestWEBrickHTTPServer < Test::Unit::TestCase
       :ServerName => "localhost"
     }
     log_tester = lambda {|log, access_log|
-      assert_equal(1, log.length)
-      assert_match(/WARN  Could not determine content-length of response body./, log[0])
+      assert_empty log
     }
     TestWEBrick.start_httpserver(config, log_tester){|server, addr, port, log|
       server.mount_proc("/", lambda { |req, res|


### PR DESCRIPTION
Previously, there was no way to implement connection upgrade or proper streaming. The systems I've checked which attempt to do this end up monkey patching webrick. So, let's make it possible without monkey patching. This is required for Rack 3.

This allows streaming which uses `connection: close` when no content-length is known. It also avoided buffering the entire response which causes problems for streaming real-time responses.