### PR TITLE
Body should be non-frozen by default.

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -122,7 +122,7 @@ module WEBrick
       @status = HTTPStatus::RC_OK
       @reason_phrase = nil
       @http_version = HTTPVersion::convert(@config[:HTTPVersion])
-      @body = ''
+      @body = +""
       @keep_alive = true
       @cookies = []
       @request_method = nil
@@ -441,7 +441,7 @@ module WEBrick
     # :stopdoc:
 
     def error_body(backtrace, ex, host, port)
-      @body = +''
+      @body = +""
       @body << <<-_end_of_html_
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
 <HTML>

--- a/test/webrick/test_httpresponse.rb
+++ b/test/webrick/test_httpresponse.rb
@@ -28,6 +28,10 @@ module WEBrick
       @res.keep_alive  = true
     end
 
+    def test_response_body_not_frozen
+      refute @res.body.frozen?
+    end
+
     def test_prevent_response_splitting_headers_crlf
       res['X-header'] = "malicious\r\nCookie: cracked_indicator_for_test"
       io = StringIO.new


### PR DESCRIPTION
This is affecting Rack v2 which appends to the response body:

https://github.com/rack/rack/blob/cd4c9f0e4befccd53c3f03ed9af8c9a9c438d0a9/lib/rack/handler/webrick.rb#L119-L121