### PR TITLE
Drop commented-out line

### DIFF
--- a/lib/webrick/httputils.rb
+++ b/lib/webrick/httputils.rb
@@ -55,7 +55,6 @@ module WEBrick
       "cer"   => "application/pkix-cert",
       "crl"   => "application/pkix-crl",
       "crt"   => "application/x-x509-ca-cert",
-     #"crl"   => "application/x-pkcs7-crl",
       "css"   => "text/css",
       "dms"   => "application/octet-stream",
       "doc"   => "application/msword",


### PR DESCRIPTION
Introduced in 037e8523a55f2c986b21106ef105517179bf3574 (19 years ago).

The duplicate key of same name was in that file as well.

The value we keep, and have had since introduction, `"crl" => "application/pkix-crl"`, seems to be in harmony with the [RFC 2585](https://www.rfc-editor.org/rfc/rfc2585#section-4.2).

See
https://www.iana.org/assignments/media-types/application/pkix-crl