### PR TITLE
Fix WEBrick::TestFileHandler#test_short_filename test not working on mswin

### DIFF
--- a/test/webrick/test_filehandler.rb
+++ b/test/webrick/test_filehandler.rb
@@ -248,20 +248,15 @@ class WEBrick::TestFileHandler < Test::Unit::TestCase
   def test_short_filename
     return if File.executable?(__FILE__) # skip on strange file system
 
-    config = {
-      :CGIInterpreter => TestWEBrick::RubyBin,
-      :DocumentRoot => File.dirname(__FILE__),
-      :CGIPathEnv => ENV['PATH'],
-    }
     log_tester = lambda {|log, access_log|
       log = log.reject {|s| /ERROR `.*\' not found\./ =~ s }
       log = log.reject {|s| /WARN  the request refers nondisclosure name/ =~ s }
       assert_equal([], log)
     }
-    TestWEBrick.start_httpserver(config, log_tester) do |server, addr, port, log|
+    TestWEBrick.start_cgi_server({}, log_tester) do |server, addr, port, log|
       http = Net::HTTP.new(addr, port)
       if windows?
-        root = config[:DocumentRoot].tr("/", "\\")
+        root = File.dirname(__FILE__).tr("/", "\\")
         fname = IO.popen(%W[dir /x #{root}\\webrick_long_filename.cgi], encoding: "binary", &:read)
         fname.sub!(/\A.*$^$.*$^$/m, '')
         if fname


### PR DESCRIPTION
The test is currently skipped and can't possibly work on windows at the moment. It fails because $LOAD_PATH is not set up properly in the forked CGI process, so require 'uri' fails.  This works properly in the test_cgi.rb tests, because it sets up a :RequestCallback to fix things up. Let's move the setup there into util.rb, so it can be shared with test_filehandler.rb as well.