### PR TITLE
Merge multiple cookie headers, preserving semantic correctness.

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -318,7 +318,7 @@ module WEBrick
     def [](header_name)
       if @header
         value = @header[header_name.downcase]
-        value.empty? ? nil : value.join(", ")
+        value.empty? ? nil : value.join
       end
     end
 
@@ -329,7 +329,7 @@ module WEBrick
       if @header
         @header.each{|k, v|
           value = @header[k]
-          yield(k, value.empty? ? nil : value.join(", "))
+          yield(k, value.empty? ? nil : value.join)
         }
       end
     end

--- a/lib/webrick/httputils.rb
+++ b/lib/webrick/httputils.rb
@@ -152,6 +152,22 @@ module WEBrick
     # Parses an HTTP header +raw+ into a hash of header fields with an Array
     # of values.
 
+    class SplitHeader < Array
+      def join(separator = ", ")
+        super
+      end
+    end
+
+    class CookieHeader < Array
+      def join(separator = "; ")
+        super
+      end
+    end
+
+    HEADER_CLASSES = Hash.new(SplitHeader).update({
+      "cookie" => CookieHeader,
+    })
+
     def parse_header(raw)
       header = Hash.new([].freeze)
       field = nil
@@ -160,7 +176,7 @@ module WEBrick
         when /^([A-Za-z0-9!\#$%&'*+\-.^_`|~]+):(.*?)\z/om
           field, value = $1, $2.strip
           field.downcase!
-          header[field] = [] unless header.has_key?(field)
+          header[field] = HEADER_CLASSES[field].new unless header.has_key?(field)
           header[field] << value
         when /^\s+(.*?)/om
           value = line.strip

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -532,4 +532,11 @@ GET /
       req.parse(StringIO.new(""))
     }
   end
+
+  def test_cookie_join
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    req.parse(StringIO.new("GET / HTTP/1.1\r\ncookie: a=1\r\ncookie: b=2\r\n\r\n"))
+    assert_equal 2, req.cookies.length
+    assert_equal 'a=1; b=2', req['cookie']
+  end
 end


### PR DESCRIPTION
HTTP/1 specifies user agent MUST only give one `cookie` header. However, in practice, servers should be robust when encountering more than one, merging them, and preserving the semantics.

WEBrick already correctly handles this case, but it fails to correct expose the headers.

See <https://github.com/socketry/rack-conform/pull/19> for more context.
