### PR TITLE
Test on macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,15 @@ jobs:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-latest ]
+        exclude:
+          - os: macos-latest
+            ruby: "2.4"
+          - os: macos-latest
+            ruby: "2.5"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,13 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest ]
+        # CRuby < 2.6 does not support macos-arm64, so test those on amd64 instead
         exclude:
-          - os: macos-latest
-            ruby: "2.4"
-          - os: macos-latest
-            ruby: "2.5"
+        - { os: macos-latest, ruby: '2.4' }
+        - { os: macos-latest, ruby: '2.5' }
+        include:
+        - { os: macos-13, ruby: '2.4' }
+        - { os: macos-13, ruby: '2.5' }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Followup: https://github.com/ruby/webrick/pull/131

But exclude Ruby 2.4 and 2.5 because they aren't supported on macos-arm64.