### PR TITLE
Treat missing CRLF separator after headers as an EOFError

### DIFF
--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -86,6 +86,7 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
       msg = <<~HTTP.gsub("\n", "\r\n")
         GET / HTTP/1.1
         Content-Length:#{cl}
+
       HTTP
       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
       assert_raise(WEBrick::HTTPStatus::BadRequest){
@@ -101,7 +102,7 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
       \r
     HTTP
     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
-    assert_raise(WEBrick::HTTPStatus::BadRequest){
+    assert_raise(WEBrick::HTTPStatus::EOFError){
       req.parse(StringIO.new(msg))
     }
   end
@@ -210,6 +211,7 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
       GET / HTTP/1.1
       Content-Length: 1
       Content-Length: 2
+
     HTTP
     req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
     assert_raise(WEBrick::HTTPStatus::BadRequest){
@@ -630,6 +632,25 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
     assert_raise(WEBrick::HTTPStatus::EOFError) {
       req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
       req.parse(StringIO.new(""))
+    }
+  end
+
+  def test_eof_raised_with_missing_line_between_headers_and_body
+    msg = <<~HTTP.gsub("\n", "\r\n")
+      GET / HTTP/1.0
+    HTTP
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    assert_raise(WEBrick::HTTPStatus::EOFError) {
+      req.parse(StringIO.new(msg))
+    }
+
+    msg = <<~HTTP.gsub("\n", "\r\n")
+      GET / HTTP/1.0
+      Foo: 1
+    HTTP
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    assert_raise(WEBrick::HTTPStatus::EOFError) {
+      req.parse(StringIO.new(msg))
     }
   end
 


### PR DESCRIPTION
Fix tests that did not have correctly formatted headers.

Fixes #140