### PR TITLE
Fix reference to URI::REGEXP::PATTERN::HOST

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -522,9 +522,10 @@ module WEBrick
       return URI::parse(uri.to_s)
     end
 
+    host_pattern = URI::RFC2396_Parser.new.pattern.fetch(:HOST)
+    HOST_PATTERN = /\A(#{host_pattern})(?::(\d+))?\z/n
     def parse_host_request_line(host)
-      pattern = /\A(#{URI::REGEXP::PATTERN::HOST})(?::(\d+))?\z/no
-      host.scan(pattern)[0]
+      host.scan(HOST_PATTERN)[0]
     end
 
     def read_body(socket, block)


### PR DESCRIPTION
Recent changes in the URI gem make it so that this constant may not be there. And I think even with older versions of the gem, it would depend on what the default parser was set to.

cc @jeremyevans 