### PR TITLE
Prevent request smuggling

### DIFF
--- a/lib/webrick/httprequest.rb
+++ b/lib/webrick/httprequest.rb
@@ -531,6 +531,10 @@ module WEBrick
     def read_body(socket, block)
       return unless socket
       if tc = self['transfer-encoding']
+        if self['content-length']   
+          raise HTTPStatus::BadRequest, "request with both transfer-encoding and content-length, possible request smuggling"
+        end
+
         case tc
         when /\Achunked\z/io then read_chunked(socket, block)
         else raise HTTPStatus::NotImplemented, "Transfer-Encoding: #{tc}."

--- a/test/webrick/test_httprequest.rb
+++ b/test/webrick/test_httprequest.rb
@@ -219,6 +219,24 @@ class TestWEBrickHTTPRequest < Test::Unit::TestCase
     }
   end
 
+  def test_content_length_and_transfer_encoding_headers_smuggling
+    msg = <<~HTTP.gsub("\n", "\r\n")
+      POST /user HTTP/1.1
+      Content-Length: 28
+      Transfer-Encoding: chunked
+
+      0
+
+      GET /admin HTTP/1.1
+
+    HTTP
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    req.parse(StringIO.new(msg))
+    assert_raise(WEBrick::HTTPStatus::BadRequest){
+      req.body
+    }
+  end
+
   def test_parse_headers
     msg = <<~HTTP.gsub("\n", "\r\n")
       GET /path HTTP/1.1


### PR DESCRIPTION
If a request has both a content-length and transfer-encoding headers, return a 400 response.  This is allowed by RFC 7230 section 3.3.3.3.

Fixes #145