### PR TITLE
Fix: Handle client connection reset for keep-alive connections

### DIFF
--- a/lib/webrick/httpserver.rb
+++ b/lib/webrick/httpserver.rb
@@ -79,7 +79,12 @@ module WEBrick
             timeout -= 0.5
           end
           raise HTTPStatus::EOFError if timeout <= 0 || @status != :Running
-          raise HTTPStatus::EOFError if sock.eof?
+          begin
+            raise HTTPStatus::EOFError if sock.eof?
+          rescue Errno::ECONNRESET
+            raise HTTPStatus::EOFError
+          end
+
           req.parse(sock)
           res.request_method = req.request_method
           res.request_uri = req.request_uri


### PR DESCRIPTION
See https://github.com/ruby/webrick/pull/86

`TCPSocket#eof?` will raise `Errno::ECONNRESET` if the connection has been reset. This is currently not handled properly in `WEBrick::HTTPServer#run`. This was reported by @carlhoerberg, but incorrectly addressed in https://github.com/ruby/webrick/pull/86.

Preconditions to hit this issue:

* Client has to request with `Connection: keep-alive`
* WEBrick has to respect that (e.g. errors / 404s do close the connection)
* Client resets the connection after the first request

This will leave the server believe that the connection is still good and fail in `WEBrick::HTTPServer#run` when testing `TCPSocket#eof?` in the next iteration of `#run`.

Testing this is a little tricky, here is how I approached it:

* start a test server, using `WEBrick::HTTPServer`
* setup a success response on `/`
* do a single request with `Connection: keep-alive`
* after reading the response body, fish the `TCPSocket` object out of the `Net::HTTP` instance and configure it to linger on close and forcefully reset the connection, dropping all remaining data. This will send a `RST` to the server
* to avoid `TestWEBrick` shutting down, before we hit the issue, we need to wait a little bit