### PR TITLE
Adding support for configurable TLS version

### DIFF
--- a/lib/webrick/ssl.rb
+++ b/lib/webrick/ssl.rb
@@ -78,6 +78,8 @@ module WEBrick
       :SSLVerifyClient      => ::OpenSSL::SSL::VERIFY_NONE,
       :SSLVerifyDepth       => nil,
       :SSLVerifyCallback    => nil,   # custom verification
+      :SSLMinVersion        => OpenSSL::SSL::TLS1_VERSION,
+      :SSLMaxVersion        => OpenSSL::SSL::TLS1_2_VERSION,
       :SSLTimeout           => nil,
       :SSLOptions           => nil,
       :SSLCiphers           => nil,
@@ -201,6 +203,8 @@ module WEBrick
       ctx.verify_mode = config[:SSLVerifyClient]
       ctx.verify_depth = config[:SSLVerifyDepth]
       ctx.verify_callback = config[:SSLVerifyCallback]
+      ctx.min_version = config[:SSLMinVersion]
+      ctx.max_version = config[:SSLMaxVersion]
       ctx.servername_cb = config[:SSLServerNameCallback] || proc { |args| ssl_servername_callback(*args) }
       ctx.timeout = config[:SSLTimeout]
       ctx.options = config[:SSLOptions]

--- a/test/webrick/test_ssl_server.rb
+++ b/test/webrick/test_ssl_server.rb
@@ -20,6 +20,15 @@ class TestWEBrickSSLServer < Test::Unit::TestCase
     )
   end
 
+  def test_tls1_3
+    assert_self_signed_cert(
+      :SSLEnable => true,
+      :SSLCertName => [["C", "JP"], ["O", "www.ruby-lang.org"], ["CN", "Ruby"]],
+      :SSLMinVersion => OpenSSL::SSL::TLS1_3_VERSION,
+      :SSLMaxVersion => OpenSSL::SSL::TLS1_3_VERSION
+    )
+  end
+
   def test_self_signed_cert_server_with_string
     assert_self_signed_cert(
       :SSLEnable => true,


### PR DESCRIPTION
Currently the OpenSSL configuration of the socket doesnt take the TLS version as input. This PR will add that support and help in configuring the server to use desired TLS version