### PR TITLE
Add cgi_mode to parse_header to support LF in CGI headers

### DIFF
--- a/lib/webrick/httpservlet/cgihandler.rb
+++ b/lib/webrick/httpservlet/cgihandler.rb
@@ -96,7 +96,7 @@ module WEBrick
           "Premature end of script headers: #{@script_filename}" if body.nil?
 
         begin
-          header = HTTPUtils::parse_header(raw_header)
+          header = HTTPUtils::parse_header(raw_header, true)
           if /^(\d+)/ =~ header['status'][0]
             res.status = $1.to_i
             header.delete('status')

--- a/sig/httputils.rbs
+++ b/sig/httputils.rbs
@@ -26,7 +26,7 @@ module WEBrick
 
     HEADER_CLASSES: Hash[String, untyped]
 
-    def self?.parse_header: (String raw) -> Hash[String, Array[String]]
+    def self?.parse_header: (String raw, ?bool cgi_mode) -> Hash[String, Array[String]]
 
     def self?.split_header_value: (String str) -> Array[String]
 

--- a/test/webrick/test_cgi.rb
+++ b/test/webrick/test_cgi.rb
@@ -145,4 +145,15 @@ class TestWEBrickCGI < Test::Unit::TestCase
       assert_not_match(CtrlPat, s)
     }
   end
+
+  def test_bare_lf_in_cgi_header
+    TestWEBrick.start_cgi_server do |server, addr, port, log|
+      http = Net::HTTP.new(addr, port)
+      req = Net::HTTP::Get.new("/webrick_bare_lf.cgi")
+      assert_nothing_raised do
+        res = http.request(req)
+        assert_equal res['Content-Type'], 'text/plain'
+      end
+    end
+  end
 end

--- a/test/webrick/webrick_bare_lf.cgi
+++ b/test/webrick/webrick_bare_lf.cgi
@@ -1,0 +1,8 @@
+#!ruby
+
+body = "test for bare LF in cgi header"
+
+print "Content-Type: text/plain\n"
+print "Content-Length: #{body.size}\n"
+print "\n"
+print body


### PR DESCRIPTION
fixes #165 

Adds `cgi_mode` option to `parse_header` method to allow bare LF line breaks in CGI headers.
