### PR TITLE
Do not cache range requests

### DIFF
--- a/lib/webrick/httpservlet/filehandler.rb
+++ b/lib/webrick/httpservlet/filehandler.rb
@@ -46,12 +46,12 @@ module WEBrick
         mtime = st.mtime
         res['etag'] = sprintf("%x-%x-%x", st.ino, st.size, st.mtime.to_i)
 
-        if not_modified?(req, res, mtime, res['etag'])
-          res.body = ''
-          raise HTTPStatus::NotModified
-        elsif req['range']
+        if req['range']
           make_partial_content(req, res, @local_path, st.size)
           raise HTTPStatus::PartialContent
+        elsif not_modified?(req, res, mtime, res['etag'])
+          res.body = ''
+          raise HTTPStatus::NotModified
         else
           mtype = HTTPUtils::mime_type(@local_path, @config[:MimeTypes])
           res['content-type'] = mtype


### PR DESCRIPTION
File streaming, at least for videos is broken in the current version of Webrick
![image](https://github.com/user-attachments/assets/c1c784ed-e0fe-4c06-8aa7-283b4f89220d)

It seems that Chrome (and other browsers?) closes the initial `Range` request early, as such the server believes that the rest of the file is cached by the browser despite this not being the case.  
As such, when the browser requests the rest of the file, the server responds with 304 - which causes streaming to fail

A simple fix for this is simply to not cache range requests