### PR TITLE
CI: macos-13 is retired, drop it from the matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,6 @@ jobs:
         exclude:
         - { os: macos-latest, ruby: '2.4' }
         - { os: macos-latest, ruby: '2.5' }
-        include:
-        - { os: macos-13, ruby: '2.4' }
-        - { os: macos-13, ruby: '2.5' }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Currently, the CI fails to build, due to one named kind of macOS image not being available.

Tried to change to these image names: 

- macos-15
- macos-14

Then, I tried removing it, which gets us to green.