### PR TITLE
Clarify intended use and vulnerability handling policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ A WEBrick server can be composed of multiple WEBrick servers or servlets to prov
 
 WEBrick also includes tools for daemonizing a process and starting a process at a higher privilege level and dropping permissions.
 
-WEBrick is suitable for use in testing and for development.  However, while the developers of WEBrick will attempt to fix security issues, they do not encourage the use of WEBrick to serve production web applications that may be subject to hostile input.
+WEBrick is intended for use in testing and local development. It is not intended for production use, and it is not intended to receive traffic from untrusted sources.
+
+The developers of WEBrick will attempt to fix security issues, and they do so in the open, through the ordinary bug fixing process on GitHub. Because WEBrick is not intended to receive traffic from untrusted sources, the developers do not operate a vulnerability handling process for WEBrick. They do not treat reports against WEBrick as vulnerabilities and do not request CVE IDs for them.
 
 ## Installation
 

--- a/lib/webrick.rb
+++ b/lib/webrick.rb
@@ -17,8 +17,16 @@
 #
 # == Security
 #
-# *Warning:* WEBrick is not recommended for production.  It only implements
-# basic security checks.
+# *Warning:* WEBrick is not intended for production use.  It is intended for
+# use in testing and local development, and it is not intended to receive
+# traffic from untrusted sources.  It only implements basic security checks.
+#
+# The developers of WEBrick will attempt to fix security issues, and they do
+# so in the open, through the ordinary bug fixing process.  Because WEBrick
+# is not intended to receive traffic from untrusted sources, the developers
+# do not operate a vulnerability handling process for WEBrick.  They do not
+# treat reports against WEBrick as vulnerabilities and do not request CVE
+# IDs for them.
 #
 # == Starting an HTTP server
 #


### PR DESCRIPTION
Follow-up to the discussion in https://github.com/ruby/webrick/pull/199. The README and the `lib/webrick.rb` rdoc discouraged production use but said nothing about how reports are handled, so the basis for treating them as non-vulnerabilities had to be explained again in each discussion. Both documents now state that WEBrick is intended for testing and local development and is not intended to receive traffic from untrusted sources, and that while security issues are fixed in the open through the ordinary bug fixing process, the developers do not operate a vulnerability handling process for WEBrick and do not request CVE IDs. Documentation only, no code changes.

Generated with [Claude Code](https://claude.com/claude-code)
